### PR TITLE
Adding support to Tesseract Layout

### DIFF
--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -239,7 +239,8 @@ class TextBuilder(object):
     tesseract_configs = []
     cuneiform_args = ["-f", "text"]
 
-    def __init__(self):
+    def __init__(self, tesseract_layout=3):
+        self.tesseract_configs = ["-psm", str(tesseract_layout)]
         pass
 
     @staticmethod


### PR DESCRIPTION
Hello Ross,

recently I had to use it in some documents that had to be processed using the tesseract option '-psm' set to 6 (the default is 3).

Please consider adding these modifications to your code in order to allow modifying the option values.

Modifying the TextBuilder in order to accept parameters for the tesseract '-psm' option, it defaults to 3 the default tesseract configuration.
