### PR TITLE
Allow tesseract 4.0.0alpha to be used with pyocr

### DIFF
--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -19,6 +19,7 @@ https://github.com/jflesch/python-tesseract#readme
 import codecs
 import logging
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -414,6 +415,13 @@ def get_version():
     Exception:
         TesseractError --- Unable to run tesseract or to parse the version
     """
+    def digits(string):
+        """Return all digits that the given string starts with."""
+        match = re.match(r'(?P<digits>\d+)', string)
+        if match:
+            return match.group('digits')
+        return ""
+
     _set_environment()
 
     command = [TESSERACT_CMD, "-v"]
@@ -436,7 +444,7 @@ def get_version():
             ver_string = ver_string[:index]
 
         els = ver_string.split(".")
-        els = [int(x) for x in els]
+        els = [int(digits(x)) for x in els]
         major = els[0]
         minor = els[1]
         upd = 0


### PR DESCRIPTION
The current tesseract 4.0 version is still in alpha and returns the version string  `tesseract 4.00.00alpha`. This breaks the existing `get_version` function as it expects integer values only.

To work around it this pull request simply only takes the starting digits of the version and returns these.

**Note:**
I haven't really tried out how pyocr fares with tesseract 4. But, I am using it with [paperless](https://github.com/danielquinn/paperless) and it seems to be working fine for me so far.

**How to test this:**
* build and install the current tesseract 4.0.0alpha
* start consumption with paperless for example
* the current pyocr version fails with `pyocr.error.TesseractError: (0, 'Unable to parse Tesseract version (not a number): [4.00.00alpha]')`