### PR TITLE
suppress debug messages in libtesseract's image_to_string()

### DIFF
--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -14,6 +14,7 @@ PyOCR is released under the GPL v3.
 Copyright (c) Jerome Flesch, 2011-2016
 https://github.com/jflesch/pyocr#readme
 '''
+from os import devnull
 from .. import builders
 from . import tesseract_raw
 from ..error import TesseractError
@@ -103,6 +104,7 @@ def image_to_string(image, lang=None, builder=None):
         tesseract_raw.set_page_seg_mode(
             handle, builder.tesseract_layout
         )
+        tesseract_raw.set_debug_file(handle, devnull)
 
         tesseract_raw.set_image(handle, image)
         if "digits" in builder.tesseract_configs:

--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -358,6 +358,20 @@ def set_is_numeric(handle, mode):
     )
 
 
+def set_debug_file(handle, filename):
+    global g_libtesseract
+    assert(g_libtesseract)
+
+    if not isinstance(filename, bytes):
+        filename = filename.encode('utf-8')
+
+    g_libtesseract.TessBaseAPISetVariable(
+        ctypes.c_void_p(handle),
+        b"debug_file",
+        filename
+    )
+
+
 def set_page_seg_mode(handle, mode):
     global g_libtesseract
     assert(g_libtesseract)


### PR DESCRIPTION
Any users of the libtesseract API are unlikely to want debug messages getting printed on stderr, which is what happens right now.

This required introducing `set_debug_file()` in the raw Tesseract API.