### PR TITLE
Fix tessdata dir error

### DIFF
--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -159,8 +159,7 @@ def image_to_string(image, lang=None, builder=None):
     return builder.get_output()
 
 
-def image_to_pdf(image, output_file, lang=None, input_file="stdin",
-                 tessdata_dir=None, textonly=False):
+def image_to_pdf(image, output_file, lang=None, input_file="stdin", textonly=False):
     '''
     Creates pdf file with embeded text based on OCR from an image
 
@@ -175,8 +174,6 @@ def image_to_pdf(image, output_file, lang=None, input_file="stdin",
             output pdf. If not specified (stdin, incorrect file) output pdf is
             correct but tesseract writes some errors about not being able to
             open the file. Defaults to stdin.
-        tessdata_dir: path to tessdata directory. Defaults to the value built in
-            libtesseract.
         textonly: create pdf with only one invisible text layer. Defaults to
             False.
     '''
@@ -192,7 +189,7 @@ def image_to_pdf(image, output_file, lang=None, input_file="stdin",
         tesseract_raw.recognize(handle)
 
         renderer = tesseract_raw.init_pdf_renderer(
-            handle, output_file, tessdata_dir, textonly
+            handle, output_file, textonly
         )
         assert(renderer)
 

--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -129,7 +129,8 @@ if g_libtesseract:
     g_libtesseract.TessBaseAPIGetDatapath.argtypes = [
         ctypes.c_void_p,  # TessBaseAPI*
     ]
-    g_libtesseract.TessBaseAPIGetDatapath.restype = ctypes.c_char_p
+    g_libtesseract.TessBaseAPIGetDatapath.restype = ctypes.POINTER(
+        ctypes.c_char)
 
     g_libtesseract.TessBaseAPIInit1.argtypes = [
         ctypes.c_void_p,  # TessBaseAPI*
@@ -636,14 +637,11 @@ def set_input_name(handle, input_file):
     )
 
 
-def init_pdf_renderer(handle, output_file, tessdata_dir, textonly):
+def init_pdf_renderer(handle, output_file, textonly):
     global g_libtesseract
     assert(g_libtesseract)
 
-    if tessdata_dir is not None:
-        tessdata_dir = tessdata_dir.encode()
-    else:
-        tessdata_dir = g_libtesseract.TessBaseAPIGetDatapath(handle)
+    tessdata_dir = g_libtesseract.TessBaseAPIGetDatapath(handle)
 
     renderer = g_libtesseract.TessPDFRendererCreate(
         output_file.encode(),


### PR DESCRIPTION
This lets Tesseract handle pathing for tessdata directory. Also resolves error `Can not open file "?????/pdf.ttf"!`.