### PR TITLE
[Fix]: Force use of legacy model for OSD

### DIFF
--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -179,6 +179,10 @@ def detect_orientation(image, lang=None):
     _set_environment()
     with temp_dir() as tmpdir:
         command = [TESSERACT_CMD, "input.bmp", 'stdout', "-psm", "0"]
+        version = get_version()
+        if version[0] >= 4:
+            # XXX: temporary fix to remove once Tesseract 4 is stable
+            command += ["--oem", "0"]
         if lang is not None:
             command += ['-l', lang]
 


### PR DESCRIPTION
Orientation and script detection (OSD) doesn't work yet with the new LSTM models shipped with Tesseract 4. 

Calling `detect_orientation` will thus fail when using tesseract 4.0 and both legacy and LSTM models are found in the TESSDATA_PREFIX directory. 

The fix is to force the use of the old legacy model until support for OSD is available in the new models.