### PR TITLE
[Enhancement]: Propagate ocr confidence to output hocr file

### DIFF
--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -12,8 +12,11 @@ except ImportError:
     from html.parser import HTMLParser
 
 import xml.dom.minidom
+import logging
 
 from .util import to_unicode
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'Box',
@@ -398,7 +401,7 @@ class _WordHTMLParser(HTMLParser):
                 continue
             confidence = piece.split(" ")[1]
             return int(confidence)
-        raise Exception("Invalid hocr confidence measure: %s" % title)
+        logger.info("OCR confidence measure not found")
 
     @staticmethod
     def __parse_position(title):

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -42,7 +42,7 @@ class Box(object):
     was used.
     """
 
-    def __init__(self, content, position, confidence=None):
+    def __init__(self, content, position, confidence=0):
         """
         Arguments:
             content --- a single string
@@ -61,9 +61,8 @@ class Box(object):
         This string can be stored in a file as-is (see write_box_file())
         and reread using read_box_file().
         """
-        return to_unicode("%s %s %d %d %d %d") % (
+        return to_unicode("%s %d %d %d %d") % (
             self.content,
-            self.confidence,
             self.position[0][0],
             self.position[0][1],
             self.position[1][0],
@@ -332,7 +331,7 @@ class TextBuilder(BaseBuilder):
     def start_line(self, box):
         self.built_text.append(u"")
 
-    def add_word(self, word, box, confidence=None):
+    def add_word(self, word, box, confidence=0):
         if self.built_text[-1] != u"":
             self.built_text[-1] += u" "
         self.built_text[-1] += word

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -402,6 +402,7 @@ class _WordHTMLParser(HTMLParser):
             confidence = piece.split(" ")[1]
             return int(confidence)
         logger.info("OCR confidence measure not found")
+        return 0
 
     @staticmethod
     def __parse_position(title):

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -273,7 +273,7 @@ class BaseBuilder(object):
         """
         raise NotImplementedError("Implement in subclasses")
 
-    def add_word(self, word, box, confidence):
+    def add_word(self, word, box, confidence=0):
         """
         Add a word to output.
         """
@@ -615,7 +615,7 @@ class WordBoxBuilder(BaseBuilder):
     def start_line(self, box):
         pass
 
-    def add_word(self, word, box, confidence):
+    def add_word(self, word, box, confidence=0):
         self.word_boxes.append(Box(word, box, confidence))
 
     def end_line(self):
@@ -699,7 +699,7 @@ class LineBoxBuilder(BaseBuilder):
             return
         self.lines.append(LineBox([], box))
 
-    def add_word(self, word, box, confidence):
+    def add_word(self, word, box, confidence=0):
         self.lines[-1].word_boxes.append(Box(word, box, confidence))
 
     def end_line(self):

--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -140,13 +140,17 @@ def image_to_string(image, lang=None, builder=None):
                 res_iterator, lvl_word
             )
 
-            if word is not None and word != "":
+            confidence = tesseract_raw.result_iterator_get_confidence(
+                res_iterator, lvl_word
+            )
+
+            if word is not None and confidence is not None and word != "":
                 (r, box) = tesseract_raw.page_iterator_bounding_box(
                     page_iterator, lvl_word
                 )
                 assert(r)
                 box = _tess_box_to_pyocr_box(box)
-                builder.add_word(word, box)
+                builder.add_word(word, box, confidence)
 
                 if last_word_in_line:
                     builder.end_line()

--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -298,6 +298,12 @@ if g_libtesseract:
     g_libtesseract.TessResultIteratorGetUTF8Text.restype = \
         ctypes.c_void_p
 
+    g_libtesseract.TessResultIteratorConfidence.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int,
+    ]
+    g_libtesseract.TessResultIteratorConfidence.restype = ctypes.c_float
+
     g_libtesseract.TessDeleteText.argtypes = [
         ctypes.c_void_p
     ]
@@ -586,6 +592,14 @@ def result_iterator_get_utf8_text(iterator, level):
     g_libtesseract.TessDeleteText(ptr)
     return val
 
+def result_iterator_get_confidence(iterator, level):
+    ptr = g_libtesseract.TessResultIteratorConfidence(
+        ctypes.c_void_p(iterator), level
+    )
+    if ptr is None:
+        return None
+    val = ctypes.c_float(ptr).value
+    return val
 
 def detect_os(handle):
     global g_libtesseract


### PR DESCRIPTION
This PR allows to parse the individual **word** confidence measures from Tesseract output and write them to the simplified output hocr file in the title attribute of the Box objects. 

Example output: `<span class="ocrx_word" title="bbox 638 1797 751 1823; x_wconf 70">Word</span>`

Note: directly relates to #74 and #58 and less so to #12