### PR TITLE
Use `str()` instead of `.message` for exception

### DIFF
--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -221,7 +221,7 @@ def detect_orientation(image, lang=None):
             }
         except Exception as ex:
             raise TesseractError(-1, "No script found in image (%s - %s)"
-                                 % (ex.message, original_output))
+                                 % (str(ex), original_output))
 
 
 def get_name():


### PR DESCRIPTION
In a case where a `KeyError` is raised, the exception is caught, but then it tried to reference `ex.message`, which doesn't exist for KeyErrors in modern versions of Python.  Using `str(ex)` should deliver the same result.