### PR TITLE
Update pyocr to use psm_parameter based on tesseract version

### DIFF
--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -14,7 +14,7 @@ except ImportError:
 import xml.dom.minidom
 import logging
 
-from .tesseract import psm_parameter
+import pyocr.tesseract
 from .util import to_unicode
 
 logger = logging.getLogger(__name__)
@@ -306,7 +306,7 @@ class TextBuilder(BaseBuilder):
     def __init__(self, tesseract_layout=3, cuneiform_dotmatrix=False,
                  cuneiform_fax=False, cuneiform_singlecolumn=False):
         file_ext = ["txt"]
-        tess_flags = [psm_parameter(), str(tesseract_layout)]
+        tess_flags = [pyocr.tesseract.psm_parameter(), str(tesseract_layout)]
         cun_args = ["-f", "text"]
         # Add custom cuneiform parameters if needed
         for par, arg in [(cuneiform_dotmatrix, "--dotmatrix"),
@@ -563,7 +563,7 @@ class WordBoxBuilder(BaseBuilder):
 
     def __init__(self, tesseract_layout=1):
         file_ext = ["html", "hocr"]
-        tess_flags = [psm_parameter(), str(tesseract_layout)]
+        tess_flags = [pyocr.tesseract.psm_parameter(), str(tesseract_layout)]
         tess_conf = ["hocr"]
         cun_args = ["-f", "hocr"]
         super(WordBoxBuilder, self).__init__(file_ext, tess_flags, tess_conf,
@@ -639,7 +639,7 @@ class LineBoxBuilder(BaseBuilder):
 
     def __init__(self, tesseract_layout=1):
         file_ext = ["html", "hocr"]
-        tess_flags = [psm_parameter(), str(tesseract_layout)]
+        tess_flags = [pyocr.tesseract.psm_parameter(), str(tesseract_layout)]
         tess_conf = ["hocr"]
         cun_args = ["-f", "hocr"]
         super(LineBoxBuilder, self).__init__(file_ext, tess_flags, tess_conf,

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -14,7 +14,6 @@ except ImportError:
 import xml.dom.minidom
 import logging
 
-import pyocr.tesseract
 from .util import to_unicode
 
 logger = logging.getLogger(__name__)
@@ -305,8 +304,9 @@ class TextBuilder(BaseBuilder):
 
     def __init__(self, tesseract_layout=3, cuneiform_dotmatrix=False,
                  cuneiform_fax=False, cuneiform_singlecolumn=False):
+        from .tesseract import psm_parameter
+        tess_flags = [psm_parameter(), str(tesseract_layout)]
         file_ext = ["txt"]
-        tess_flags = [pyocr.tesseract.psm_parameter(), str(tesseract_layout)]
         cun_args = ["-f", "text"]
         # Add custom cuneiform parameters if needed
         for par, arg in [(cuneiform_dotmatrix, "--dotmatrix"),
@@ -562,8 +562,9 @@ class WordBoxBuilder(BaseBuilder):
     """
 
     def __init__(self, tesseract_layout=1):
+        from .tesseract import psm_parameter
+        tess_flags = [psm_parameter(), str(tesseract_layout)]
         file_ext = ["html", "hocr"]
-        tess_flags = [pyocr.tesseract.psm_parameter(), str(tesseract_layout)]
         tess_conf = ["hocr"]
         cun_args = ["-f", "hocr"]
         super(WordBoxBuilder, self).__init__(file_ext, tess_flags, tess_conf,
@@ -638,8 +639,9 @@ class LineBoxBuilder(BaseBuilder):
     """
 
     def __init__(self, tesseract_layout=1):
+        from .tesseract import psm_parameter
+        tess_flags = [psm_parameter(), str(tesseract_layout)]
         file_ext = ["html", "hocr"]
-        tess_flags = [pyocr.tesseract.psm_parameter(), str(tesseract_layout)]
         tess_conf = ["hocr"]
         cun_args = ["-f", "hocr"]
         super(LineBoxBuilder, self).__init__(file_ext, tess_flags, tess_conf,

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -164,10 +164,7 @@ def can_detect_orientation():
 def psm_parameter():
     """Return the psm option string depending on the Tesseract version."""
     version = get_version()
-    if version[0] <= 3:
-        return "-psm"
-
-    return "--psm"
+    return "--psm" if version[0] > 3 else "-psm"
 
 
 def detect_orientation(image, lang=None):

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -27,7 +27,7 @@ import shutil
 
 from . import builders
 from . import util
-import pyocr.builders  # backward compatibility
+from .builders import DigitBuilder  # backward compatibility
 from .error import TesseractError  # backward compatibility
 from .util import digits_only
 
@@ -240,7 +240,7 @@ def get_available_builders():
         builders.TextBuilder,
         builders.WordBoxBuilder,
         CharBoxBuilder,
-        pyocr.builders.DigitBuilder,
+        builders.DigitBuilder,
     ]
 
 

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -27,7 +27,7 @@ import shutil
 
 from . import builders
 from . import util
-from .builders import DigitBuilder  # backward compatibility
+import pyocr.builders  # backward compatibility
 from .error import TesseractError  # backward compatibility
 from .util import digits_only
 
@@ -240,7 +240,7 @@ def get_available_builders():
         builders.TextBuilder,
         builders.WordBoxBuilder,
         CharBoxBuilder,
-        builders.DigitBuilder,
+        pyocr.builders.DigitBuilder,
     ]
 
 


### PR DESCRIPTION
Let's try again after https://github.com/openpaperwork/pyocr/pull/100 did not quite work. This should fix https://github.com/openpaperwork/pyocr/issues/99.

We now
- use the psm parameter based on the tesseract version
- only import the `psm_parameter` function in `builders.py` when it is needed; this avoids circular import issues between `builders.py` and `tesseract.py`. This is not great, but the best/simplest solution I could come up with.

Thanks!